### PR TITLE
Fast computation of gradient on a mesh

### DIFF
--- a/slam/differential_geometry.py
+++ b/slam/differential_geometry.py
@@ -484,7 +484,7 @@ def gradient_fast(mesh, texture_array):
     grad_triangle = texture[mesh.faces[:, 0]] * e_jk + texture[mesh.faces[:, 1]] * e_ki \
                     + texture[mesh.faces[:, 2]] * e_ij
 
-    grad_triangle = -1/(2*A) * cross_product(N, grad_triangle)
+    grad_triangle = 1/(2*A) * cross_product(N, grad_triangle)
 
     # From faces to vertices, use the Nvertex x Ntriangles sparse matrix correspondance
     grad_vertex = mesh.faces_sparse * grad_triangle

--- a/slam/differential_geometry.py
+++ b/slam/differential_geometry.py
@@ -439,6 +439,59 @@ def triangle_gradient(mesh, texture_array):
 
     return dicgrad
 
+def cross_product(vec1, vec2):
+    if vec1.shape != vec2.shape:
+        raise Exception("Not the same size")
+
+    res = np.zeros(vec1.shape)
+    res[:, 0] = vec1[:, 1]*vec2[:, 2]-vec1[:, 2]*vec2[:, 1]
+    res[:, 1] = vec1[:, 2]*vec2[:, 0]-vec1[:, 0]*vec2[:, 2]
+    res[:, 2] = vec1[:, 0]*vec2[:, 1]-vec1[:, 1]*vec2[:, 0]
+
+    return res
+
+def gradient_fast(mesh, texture_array):
+    """
+    Compute gradient on a triangular mesh with a scalar function.
+    Gradient is computed on each triangle by the function described in
+    http://dgd.service.tu-berlin.de/wordpress/vismathws10/2012/10/
+    17/gradient-of-scalar-functions/.
+
+    Formula for the triangle
+    grad(f) = - (1/2A) N x (f_i e_{jk} + f_j e_{ik} + f_k e_{ij} )
+    And for a mesh
+    grad(f) = 1/nb_neighbours * sum(grad_f on each triangle)
+
+    Faster version by using numpy (J Lefevre)
+    :param mesh: Triangular mesh
+    :param texture_array: Scalar function on Vertices, numpy array
+    :return: Gradient on Vertices
+    :rtype: numpy.array
+    """
+    n_tri = mesh.faces.shape[0]
+    n_vertex = mesh.vertices.shape[0]
+    texture = np.reshape(texture_array,(n_vertex,1))
+
+    e_ij = mesh.vertices[mesh.faces[:, 1],:] - mesh.vertices[mesh.faces[:, 0],:]
+    e_ki = mesh.vertices[mesh.faces[:, 0],:] - mesh.vertices[mesh.faces[:, 2],:]
+    e_jk = mesh.vertices[mesh.faces[:, 2],:] - mesh.vertices[mesh.faces[:, 1],:]
+
+    N = cross_product(e_ij, e_jk)
+    A = 0.5 * np.linalg.norm(N, 2, 1)
+    A = np.reshape(A, (n_tri, 1))
+    N = 1/(2*A) * N # may raise an error or be wrong, careful with dims of A and N
+
+    grad_triangle = texture[mesh.faces[:, 0]] * e_jk + texture[mesh.faces[:, 1]] * e_ki \
+                    + texture[mesh.faces[:, 2]] * e_ij
+
+    grad_triangle = -1/(2*A) * cross_product(N, grad_triangle)
+
+    # From faces to vertices, use the Nvertex x Ntriangles sparse matrix correspondance
+    grad_vertex = mesh.faces_sparse * grad_triangle
+    grad_vertex = grad_vertex * np.reshape(1/mesh.vertex_degree, (n_vertex, 1))
+
+    return grad_vertex
+
 
 def gradient(mesh, texture_array):
     """

--- a/tests/test_differential_geometry.py
+++ b/tests/test_differential_geometry.py
@@ -4,21 +4,49 @@ import numpy as np
 import trimesh
 
 import slam.differential_geometry as sdg
-
+import slam.generate_parametric_surfaces as sgpm
 
 TOL = 1e-15
+TOL2 = 1e-1
+
+
+def cartesian_to_spherical(coords):
+    n = len(coords)
+    spherical_coordinates = np.zeros((n,3))
+    for i in range(n):
+        R = np.sqrt(np.sum(coords[i,:]**2))
+        spherical_coordinates[i,0] = R
+        coord_i = coords[i,:] / R
+        spherical_coordinates[i,2] = np.arctan2(coord_i[1],coord_i[0]) # Phi, in [0,2pi]
+        spherical_coordinates[i,1] = np.arccos(coord_i[2]) # Theta, in [0,pi]
+    return spherical_coordinates
 
 
 class TestDifferentialGeometry(unittest.TestCase):
+    # def test_gradient(self):
+    #     # Trivial example at the moment:
+    #     # Uniform texture: gradient vanishes
+    #     mesh = trimesh.creation.icosphere(subdivisions=4, radius=1.0)
+    #     n_vert = mesh.vertices.shape[0]
+    #     uniform_texture = np.ones((n_vert,))
+    #     gradient_uniform = sdg.gradient(mesh, uniform_texture)
+    #     self.assertTrue(
+    #         (np.abs(gradient_uniform - np.zeros((n_vert, 3))) < TOL).all())
+
     def test_gradient(self):
-        # Trivial example at the moment:
-        # Uniform texture: gradient vanishes
-        mesh = trimesh.creation.icosphere(subdivisions=4, radius=1.0)
-        n_vert = mesh.vertices.shape[0]
-        uniform_texture = np.ones((n_vert,))
-        gradient_uniform = sdg.gradient(mesh, uniform_texture)
-        self.assertTrue(
-            (np.abs(gradient_uniform - np.zeros((n_vert, 3))) < TOL).all())
+        sphere_mesh = sgpm.generate_sphere_icosahedron(subdivisions=4)
+        spherical_coordinates = cartesian_to_spherical(sphere_mesh.vertices)
+        phi = spherical_coordinates[:, 2]
+        theta = spherical_coordinates[:, 1]
+        gradient_theta = sdg.gradient_fast(sphere_mesh, theta)
+
+        analytic_gradient_theta = np.zeros((sphere_mesh.vertices.shape[0], 3))
+        analytic_gradient_theta[:, 0] = np.cos(theta) * np.cos(phi)
+        analytic_gradient_theta[:, 1] = np.cos(theta) * np.sin(phi)
+        analytic_gradient_theta[:, 2] = - np.sin(theta)
+        error_norms = np.sqrt(np.sum((gradient_theta - analytic_gradient_theta) ** 2, axis=1))
+        # error_norms decrease linearly with mesh spacing
+        self.assertTrue(np.mean(error_norms) < TOL2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello,

The previous code for gradient has been vectorized. Now it is called `gradient_fast`, same mathematical definition [1] and same signature as the previous `gradient` and:

- it is more than 100 times faster: on a Freesurfer mesh with 144k vertices it takes 0.1s (45s before)
- there is new unit test in `test_differential_geometry.py` on a discretized sphere where the gradient of the angle theta is used because it has a nice analytic expression depending on the spherical coordinates. Of course the error between the analytic and estimated gradient depends on the resolution so the tolerance to assert the equality should be quite large (1e-2 for icosahedron sphere with 4 subdivisions = 2500 vertices).


[1] see [here](http://dgd.service.tu-berlin.de/wordpress/vismathws10/2012/10/17/gradient-of-scalar-functions/)